### PR TITLE
ci(lint): adding a gha for linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,21 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+      - name: Run sanity checks
+        run: |
+          make verify && make lint

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -29,7 +30,9 @@ var (
 func init() {
 	rootCmd.AddCommand(evalCmd)
 	evalCmd.Flags().StringToStringVarP(&replacements, "replacement", "r", map[string]string{}, "Key value pair of comma delimited values. Example: 'NAMESPACE=foo,bar'")
-	evalCmd.MarkFlagRequired("replacement")
+	if err := evalCmd.MarkFlagRequired("replacement"); err != nil {
+		log.Fatalf("Failed to initialize binary %v", err)
+	}
 
 }
 

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -31,7 +30,8 @@ func init() {
 	rootCmd.AddCommand(evalCmd)
 	evalCmd.Flags().StringToStringVarP(&replacements, "replacement", "r", map[string]string{}, "Key value pair of comma delimited values. Example: 'NAMESPACE=foo,bar'")
 	if err := evalCmd.MarkFlagRequired("replacement"); err != nil {
-		log.Fatalf("Failed to initialize binary %v", err)
+		fmt.Fprintf(os.Stderr, "failed to initialize eval: %v", err)
+		os.Exit(1)
 	}
 
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,6 +4,8 @@ import "testing"
 
 func TestRoot(t *testing.T) {
 	t.Run("Execute", func(t *testing.T) {
-		Execute()
+		if err := Execute(); err != nil {
+			t.Fatalf("error occurred while executing command: %v", err)
+		}
 	})
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"log"
+
 	"github.com/operator-framework/combo/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,13 +1,15 @@
 package main
 
 import (
-	"log"
+	"fmt"
+	"os"
 
 	"github.com/operator-framework/combo/cmd"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		log.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/pkg/combination/combination.go
+++ b/pkg/combination/combination.go
@@ -69,10 +69,6 @@ func (cs *streamImp) Next(ctx context.Context) (map[string]string, error) {
 		}
 	}
 
-	if cs.solveAhead && !cs.solved {
-		cs.solve()
-	}
-
 	if len(cs.combinations) == 0 {
 		if cs.solved {
 			return nil, nil
@@ -125,6 +121,7 @@ func (cs *streamImp) solve() error {
 	max := len(arrays) - 1
 
 	// Define recursive function for getting combinations
+	var err error
 	var recurse func(combo map[string]string, i int)
 	recurse = func(combo map[string]string, i int) {
 		for _, val := range arrays[i] {
@@ -132,7 +129,7 @@ func (cs *streamImp) solve() error {
 			if i == max {
 				// Append a copy of the map to the combos
 				comboCopy := map[string]string{}
-				copier.Copy(&comboCopy, &combo)
+				err = copier.Copy(&comboCopy, &combo)
 				combos = append(combos, comboCopy)
 			} else {
 				recurse(combo, i+1)
@@ -142,6 +139,9 @@ func (cs *streamImp) solve() error {
 
 	// Recurse to produce combinations
 	recurse(map[string]string{}, 0)
+	if err != nil {
+		return err
+	}
 
 	cs.combinations = combos
 	cs.solved = true


### PR DESCRIPTION
# Summary
Adding a new CI action that runs the golangci-lint tool and fix the issues it output.

# Additions
- New CI action for linting and verifying code
- Fixes to appease the linter

Closes #9