### PR TITLE
Introduce a root CODEOWNERS to automatically assign reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @njhale @tylerslaton @timflannagan @awgreene


### PR DESCRIPTION
Introduce a root CODEOWNERS file that aims towards scaffolding out an
initial set of people associated with the project that github will then
use to automatically assign reviewers when pull requests are opened.

Link to the CODEOWNERS documentation:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.

Fixes #19

Signed-off-by: timflannagan <timflannagan@gmail.com>