### PR TITLE
docs(codeowners): change to use github team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @njhale @tylerslaton @timflannagan @awgreene
+* @operator-framework/combo-maintainers


### PR DESCRIPTION
Updating the code owners to reference the team created (kudos @njhale for making that!). 