### PR TITLE
Ignore the vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 combo
+vendor


### PR DESCRIPTION
Update the root .gitignore and ignore tracking any changes made to the
root vendor tree as we're not introducing that directory into source
control.

Signed-off-by: timflannagan <timflannagan@gmail.com>