### PR TITLE
ci(sanity): vendor deps before running linter

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.17'
+      - name: Vendor dependencies
+        run: go mod vendor
       - name: Run sanity checks
-        run: |
-          make verify && make lint
+        run: make verify

--- a/Makefile
+++ b/Makefile
@@ -23,22 +23,25 @@ help: ## Show this help screen
 
 PKGS = $(shell go list ./...)
 
-lint:
-	$(Q)go run github.com/golangci/golangci-lint/cmd/golangci-lint run
+tidy: ## Update dependencies
+	$(Q)go mod tidy
+
+generate: ## Generate code and manifests
+	$(Q)go generate ./...
 
 format: ## Format the source code
 	$(Q)go fmt ./...
 
-tidy: ## Update dependencies
-	$(Q)go mod tidy
+lint: ## Run golangci-lin
+	$(Q)go run github.com/golangci/golangci-lint/cmd/golangci-lint run
+
+verify: tidy generate format lint ## Verify the current code generation and lint
+	git diff --exit-code
 
 build-cli:
 	$(Q)go build -o combo
 
 CONTROLLER_GEN=$(Q)go run sigs.k8s.io/controller-tools/cmd/controller-gen
-
-generate: ## Generate code and manifests
-	$(Q)go generate ./...
 
 # Static tests.
 .PHONY: test test-unit verify build
@@ -47,12 +50,6 @@ test: test-unit ## Run the tests
 
 test-unit: ## Run the unit tests
 	$(Q)go test -count=1 -short ./...
-
-verify: tidy generate format
-	git diff --exit-code
-
-install: generate
-	kubectl apply -f manifests
 
 # Binary builds
 GO_BUILD := $(Q)go build


### PR DESCRIPTION
# Summary
As more dependencies are getting added the linter is timing out when trying to download them before its run in the `sanity` action. As a result, this PR vendors the dependencies prior so that lint step is not responsible for downloading.

# Additions
- Vendor prior to running linter in `sanity` action
- Moved around targets to be more readable