### PR TITLE
ci(sanity): add .golangci.yml with increased timeout for linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,3 @@
+run:
+  # Default timeout is 1m, up to give more room
+  timeout: 4m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,25 @@
 run:
   # Default timeout is 1m, up to give more room
   timeout: 4m
+
+linters:
+  enable:
+  - asciicheck
+  - deadcode
+  - depguard
+  - errorlint
+  - gofmt
+  - goimports
+  - importas
+  - prealloc
+  - nestif
+  - revive
+  - misspell
+  - stylecheck
+  - tparallel
+  - unconvert
+  - unparam
+  - whitespace
+
+output:
+  format: tab

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ generate: ## Generate code and manifests
 format: ## Format the source code
 	$(Q)go fmt ./...
 
-lint: ## Run golangci-lin
+lint: ## Run golangci-lint
 	$(Q)go run github.com/golangci/golangci-lint/cmd/golangci-lint run
 
 verify: tidy generate format lint ## Verify the current code generation and lint

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -37,7 +37,6 @@ func init() {
 		fmt.Fprintf(os.Stderr, "failed to initialize eval: %v", err)
 		os.Exit(1)
 	}
-
 }
 
 // run is used during the actual execution of the command to generate
@@ -49,7 +48,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := validateFile(file); err != nil {
-		return fmt.Errorf("failed to validate file specified: %v", err)
+		return fmt.Errorf("failed to validate file specified: %w", err)
 	}
 
 	combinations := combination.NewStream(
@@ -66,7 +65,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := validateFile([]byte(generatedFile)); err != nil {
-		return fmt.Errorf("failed to validate file generated: %v", err)
+		return fmt.Errorf("failed to validate file generated: %w", err)
 	}
 
 	fmt.Println(generatedFile)

--- a/pkg/combination/combination.go
+++ b/pkg/combination/combination.go
@@ -29,10 +29,10 @@ type streamImp struct {
 	solved       bool
 }
 
-type streamOption func(*streamImp)
+type StreamOption func(*streamImp)
 
 // NewStream creates a new stream and accepts stream options for it
-func NewStream(options ...streamOption) Stream {
+func NewStream(options ...StreamOption) Stream {
 	cs := &streamImp{}
 	for _, option := range options {
 		option(cs)
@@ -41,7 +41,7 @@ func NewStream(options ...streamOption) Stream {
 }
 
 // WithArgs specifies which args to utilize in the new stream
-func WithArgs(args map[string][]string) streamOption {
+func WithArgs(args map[string][]string) StreamOption {
 	return func(cs *streamImp) {
 		cs.args = args
 	}
@@ -51,7 +51,7 @@ func WithArgs(args map[string][]string) streamOption {
 // only occurs on the first call to Next or All. By using this, the Stream
 // will solve all possible combinations of its args which could take a lot
 // of computation given a large enough input.
-func WithSolveAhead() streamOption {
+func WithSolveAhead() StreamOption {
 	return func(cs *streamImp) {
 		cs.solveAhead = true
 	}
@@ -110,8 +110,8 @@ func (cs *streamImp) solve() error {
 	combos := []map[string]string{}
 
 	// Create holder arrays to process the incoming args
-	var arrays [][]string
-	var replacements []string
+	arrays := [][]string{}
+	replacements := []string{}
 	for key, val := range cs.args {
 		arrays = append(arrays, val)
 		replacements = append(replacements, key)

--- a/pkg/combination/combination_test.go
+++ b/pkg/combination/combination_test.go
@@ -2,9 +2,10 @@ package combination
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/operator-framework/combo/test/assets/combinationTestData"
+	testdata "github.com/operator-framework/combo/test/assets/combination"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,9 +29,9 @@ var combinationTests = []struct {
 	},
 	{
 		name:  "standard set of args",
-		input: combinationTestData.CombinationInput,
+		input: testdata.CombinationInput,
 		expected: expected{
-			combinations: combinationTestData.CombinationOutput,
+			combinations: testdata.CombinationOutput,
 			err:          nil,
 		},
 	},
@@ -44,7 +45,7 @@ func TestAll(t *testing.T) {
 				WithSolveAhead(),
 			)
 			got, err := combinationStream.All()
-			if err != tt.expected.err {
+			if !errors.Is(err, tt.expected.err) {
 				t.Fatal("error received while retreiving all combinations:", err)
 			}
 			require.ElementsMatch(t, got, tt.expected.combinations, "Combos generated incorrectly")
@@ -67,7 +68,7 @@ func TestNext(t *testing.T) {
 
 			for {
 				next, err := combinationStream.Next(ctx)
-				if err != tt.expected.err {
+				if !errors.Is(err, tt.expected.err) {
 					t.Fatal("error received while processing combination stream:", err)
 				}
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -70,7 +70,7 @@ func (t *Template) with(combo map[string]string, to Template) Template {
 // Evaluate uses specified template and combination stream to build/return the combinations of
 // documents built together
 func Evaluate(ctx context.Context, stringTemplate string, combinations combination.Stream) (string, error) {
-	// Separate the documents by the yaml seperator and build a template with them
+	// Separate the documents by the yaml separator and build a template with them
 	docs := strings.Split(stringTemplate, "---")
 	var splitTemplate Template
 	for _, doc := range docs {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/operator-framework/combo/pkg/combination"
-	"github.com/operator-framework/combo/test/assets/generatorTestData"
+	testdata "github.com/operator-framework/combo/test/assets/generator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,10 +25,10 @@ func TestEvaluate(t *testing.T) {
 	}{
 		{
 			name:     "can process a template",
-			template: generatorTestData.EvaluateInput,
+			template: testdata.EvaluateInput,
 			expected: expected{
 				err:        nil,
-				evaluation: generatorTestData.EvaluateOutput,
+				evaluation: testdata.EvaluateOutput,
 			},
 			combinations: combination.NewStream(
 				combination.WithArgs(map[string][]string{
@@ -66,8 +66,8 @@ func TestEvaluate(t *testing.T) {
 			assert.Equal(t, tt.expected.err, err)
 			require.ElementsMatch(
 				t,
-				strings.Split(string(tt.expected.evaluation), "---"),
-				strings.Split(string(evaluation), "---"),
+				strings.Split(tt.expected.evaluation, "---"),
+				strings.Split(evaluation, "---"),
 				"Document evaluations generated incorrectly")
 		})
 	}

--- a/test/assets/combination/testdata.go
+++ b/test/assets/combination/testdata.go
@@ -1,12 +1,12 @@
-package combinationTestData
+package testdata
 
-var CombinationInput map[string][]string = map[string][]string{
+var CombinationInput = map[string][]string{
 	"TEST1": {"foo", "bar"},
 	"TEST2": {"zip", "zap"},
 	"TEST3": {"bip", "bap"},
 }
 
-var CombinationOutput []map[string]string = []map[string]string{
+var CombinationOutput = []map[string]string{
 	{
 		"TEST1": "foo",
 		"TEST2": "zip",

--- a/test/assets/generator/testdata.go
+++ b/test/assets/generator/testdata.go
@@ -1,6 +1,6 @@
-package generatorTestData
+package testdata
 
-var EvaluateInput string = `---
+var EvaluateInput = `---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -35,7 +35,7 @@ roleRef:
 	apiGroup: rbac.authorization.k8s.io
 `
 
-var EvaluateOutput string = `---
+var EvaluateOutput = `---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
Adding a golangci.yml and increasing the linter's timeout.