### PR TITLE
.github/workflows: Notify pull request authors when workflows have failed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: build
 on:
   push:
     branches:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           make build-cli
       - name: Notify PR author when tests have failed
-        if: ${{ failure() && github.event.pull_request.draft == false }}
+        if: ${{ failure() }}
         uses: actions/github-script@v5
         with:
           script: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,3 +19,19 @@ jobs:
       - name: Build the CLI
         run: |
           make build-cli
+      - name: Notify PR author when tests have failed
+        if: ${{ failure() && github.event.pull_request.draft == false }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const comment = `
+            @${{github.actor}} The ${{ github.workflow }} workflow has *failed*.
+
+            Check out the [action page](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details on why the workflow had failed.
+            `
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment,
+            })

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: sanity
 on:
   push:
     branches:

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
+
       - name: Install Go 1.17
         uses: actions/setup-go@v2
         with:
@@ -20,3 +21,19 @@ jobs:
         run: go mod vendor
       - name: Run sanity checks
         run: make verify
+      - name: Notify PR author when tests have failed
+        if: ${{ failure() && github.event.pull_request.draft == false }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const comment = `
+            @${{github.actor}} The ${{ github.workflow }} workflow has *failed*.
+
+            Check out the [action page](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details on why the workflow had failed.
+            `
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment,
+            })

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: unit
 on:
   push:
     branches:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -19,3 +19,19 @@ jobs:
       - name: Run unit tests
         run: |
           make test-unit
+      - name: Notify PR author when tests have failed
+        if: ${{ failure() && github.event.pull_request.draft == false }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const comment = `
+            @${{github.actor}} The ${{ github.workflow }} workflow has *failed*.
+
+            Check out the [action page](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details on why the workflow had failed.
+            `
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment,
+            })

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -26,7 +26,7 @@ The replacements flag allows users to specify a series of key value pairs in the
 
 Example: combo eval -r REPLACE_ME=1,2,3 path/to/file
 	`,
-		RunE: run,
+		RunE: run,;;;
 	}
 )
 


### PR DESCRIPTION
Update the existing set of GHA workflows to notify PR authors when the workflow checks have failed. This job is triggered on non-draft PRs to avoid any rate limiting or spam notifications when iterating on WIP/draft PRs. Additionally, avoid using the same `ci` prefixed name. This can help better distinguish between individual workflows when interacting with the `actions` tab in the repositories github UI.
