### PR TITLE
.github/workflows: Enable workflow_dispatch events

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
     - '**/*.md'
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
     - '**/*.md'
+  workflow_dispatch:
 jobs:
   sanity:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
     - '**/*.md'
+  workflow_dispatch:
 jobs:
   unit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the existing set of CI-related workflows and enable the
workflow_dispatch functionality in order to have a first-class way of
triggering a workflow manually without having to entertain previous
workarounds, like opening a PR with an empty commit.

Signed-off-by: timflannagan <timflannagan@gmail.com>