### PR TITLE
.github/workflows: Avoid using the 'ci' workflow name for all CI-related actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: build
 on:
   push:
     branches:

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: sanity
 on:
   push:
     branches:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: unit
 on:
   push:
     branches:


### PR DESCRIPTION
Update any relevant CI-related workflows and avoid using the shared 'ci'
prefix for the workflow name in order better distinguish between
workflow(s) when interacting with the 'Actions' tab in the GitHub UI.

---
Screenshot of the previous behavior (using OLM as an example):

![Screenshot from 2021-11-12 12-37-59](https://user-images.githubusercontent.com/9899409/141510557-b223b691-d445-4268-9512-5544f4c562a3.png)
---

Screenshot of the new proposed behavior:

![Screenshot from 2021-11-17 12-42-48](https://user-images.githubusercontent.com/9899409/142253604-cdf6202d-902c-4e81-950c-3aed9c483995.png)
