### PR TITLE
refactor: address oustanding comments on PR #61

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,12 +16,16 @@ jobs:
       with:
         go-version: '~1.17'
     - name: Install kind
+      env:
+        KIND_VERSION: v0.11.1
+        KIND_OS: kind-linux-amd64
       run: |
-        curl -sLo kind "$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '[.assets[] | select(.name == "kind-linux-amd64")] | first | .browser_download_url')"
+        curl -sLo kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/${KIND_OS}"
         chmod +x kind
         sudo mv kind /bin/
     - name: Create kind cluster
       run: |
+        kind version
         kind create cluster
         kind export kubeconfig
     - name: Run e2e tests

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/fzipp/gocyclo v0.3.1 // indirect
 	github.com/go-critic/go-critic v0.5.6 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/go-toolsmith/astcast v1.0.0 // indirect
 	github.com/go-toolsmith/astcopy v1.0.0 // indirect
 	github.com/go-toolsmith/astequal v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,7 @@ github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8w
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-toolsmith/astcast v1.0.0 h1:JojxlmI6STnFVG9yOImLeGREv8W2ocNUM+iOhR6jE7g=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=

--- a/pkg/controller/combo_controller.go
+++ b/pkg/controller/combo_controller.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/combo/api/v1alpha1"
-	combinationPkg "github.com/operator-framework/combo/pkg/combination"
-	templatePkg "github.com/operator-framework/combo/pkg/template"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -20,6 +18,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	combinationPkg "github.com/operator-framework/combo/pkg/combination"
+	templatePkg "github.com/operator-framework/combo/pkg/template"
+)
+
+const (
+	ReferencedTemplateLabel = "combo.ReferencedTemplate"
 )
 
 type combinationController struct {
@@ -58,7 +63,7 @@ func (c *combinationController) mapTemplateToCombinations(template client.Object
 	}
 
 	// Build the label selector for querying
-	templateSelector, err := labels.Parse("combo.ReferencedTemplate=" + templateName)
+	templateSelector, err := labels.Parse(ReferencedTemplateLabel + "=" + templateName)
 	if err != nil {
 		return requests
 	}
@@ -110,7 +115,7 @@ func (c *combinationController) Reconcile(ctx context.Context, req ctrl.Request)
 	if combination.Labels == nil {
 		combination.Labels = map[string]string{}
 	}
-	combination.Labels["combo.ReferencedTemplate"] = combination.Spec.Template
+	combination.Labels[ReferencedTemplateLabel] = combination.Spec.Template
 	if err := c.Update(ctx, combination); err != nil {
 		combination.SetStatusCondition(metav1.Condition{
 			Type:               v1alpha1.TypeInvalid,

--- a/test/e2e/controller_suite_test.go
+++ b/test/e2e/controller_suite_test.go
@@ -60,13 +60,8 @@ var _ = BeforeSuite(func() {
 
 	Eventually(func() (int, error) {
 		deployment := appsv1.Deployment{}
-		deploymentNamespace := types.NamespacedName{
-			Name:      "combo-operator",
-			Namespace: "combo",
-		}
-
-		err = kubeclient.Get(ctx, deploymentNamespace, &deployment)
+		err = kubeclient.Get(ctx, types.NamespacedName{Name: "combo-operator", Namespace: "combo"}, &deployment)
 
 		return int(deployment.Status.AvailableReplicas), err
-	}).Should(BeNumerically(">", 0), "failed to validate if the combo-operator is running")
+	}).Should(Equal(1), "failed to validate if the combo-operator is running")
 })

--- a/tools.go
+++ b/tools.go
@@ -5,5 +5,6 @@ package tools
 
 import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint" // Better linting
-	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"     // Generate deepcopy, conversion, and CRDs
+	_ "github.com/onsi/ginkgo/ginkgo"
+	_ "sigs.k8s.io/controller-tools/cmd/controller-gen" // Generate deepcopy, conversion, and CRDs
 )


### PR DESCRIPTION
# Summary
Fixing a number of issues left over on PR #61 

# Fixes
* Pin specific kind version for e2e action
* Address various small code structure changes
* Update Makefile to be more idiomatic
* Remove recursive Makefile calls
* Update test-e2e and the action that calls it to use Ginkgo
* Move `kubeclient.Update()` call into Eventually handler