### PR TITLE
refactor(controller): remove ReferencedTemplate label to be more idiomatic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 ###########################
 # Configuration Variables #
 ###########################
-ORG := github.com/operator-framework
-PKG := $(ORG)/combo
+PKG := $(shell head -n 1 go.mod | awk '{print $$2}')
 VERSION_PATH := $(PKG)/pkg/version
 GIT_COMMIT := $(shell git rev-parse HEAD)
 DEFAULT_VERSION := v0.0.1

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 ###########################
 # Configuration Variables #
 ###########################
-PKG := $(shell head -n 1 go.mod | awk '{print $$2}')
+ORG := github.com/operator-framework
+PKG := $(ORG)/combo
 VERSION_PATH := $(PKG)/pkg/version
 GIT_COMMIT := $(shell git rev-parse HEAD)
 DEFAULT_VERSION := v0.0.1

--- a/pkg/controller/combo_controller.go
+++ b/pkg/controller/combo_controller.go
@@ -9,10 +9,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/combo/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -57,32 +55,24 @@ func (c *combinationController) mapTemplateToCombinations(template client.Object
 
 	// Retrieve and validate the template's name
 	templateName := template.GetName()
-	if isValid := validation.IsValidLabelValue(templateName); isValid != nil {
-		c.log.Info(fmt.Sprintf("template referenced in mapTemplateToCombinations call is not valid: %v", isValid))
-		return requests
-	}
-
-	// Build the label selector for querying
-	templateSelector, err := labels.Parse(ReferencedTemplateLabel + "=" + templateName)
-	if err != nil {
-		return requests
-	}
 
 	// Find all of the combinations that rely on this template
 	combinationList := v1alpha1.CombinationList{}
-	if err := c.List(ctx, &combinationList, &client.ListOptions{LabelSelector: templateSelector}); err != nil {
+	if err := c.List(ctx, &combinationList, &client.ListOptions{}); err != nil {
 		return requests
 	}
 
 	//  Enqueue reliant combinations for updates
 	for _, combination := range combinationList.Items {
-		c.log.Info(fmt.Sprintf("enqueueing %s combination in response to associated %s template being updated", combination.Name, templateName))
-		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      combination.Name,
-				Namespace: template.GetNamespace(),
-			},
-		})
+		if combination.Spec.Template == templateName {
+			c.log.Info(fmt.Sprintf("enqueueing %s combination in response to associated %s template being updated", combination.Name, templateName))
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      combination.Name,
+					Namespace: template.GetNamespace(),
+				},
+			})
+		}
 	}
 
 	return requests
@@ -110,22 +100,6 @@ func (c *combinationController) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Remove any previous evaluation in case of failure
 	combination.Status.Evaluations = []string{}
-
-	// Apply label for the referenced template for easy watching
-	if combination.Labels == nil {
-		combination.Labels = map[string]string{}
-	}
-	combination.Labels[ReferencedTemplateLabel] = combination.Spec.Template
-	if err := c.Update(ctx, combination); err != nil {
-		combination.SetStatusCondition(metav1.Condition{
-			Type:               v1alpha1.TypeInvalid,
-			Status:             metav1.ConditionFalse,
-			Reason:             v1alpha1.ReasonTemplateNotFound,
-			LastTransitionTime: metav1.NewTime(time.Now()),
-			Message:            fmt.Sprintf("failed to retrieve %s template: %s", combination.Spec.Template, err.Error()),
-		})
-		return reconcile.Result{}, errors.NewAggregate([]error{err, c.Status().Update(ctx, combination)})
-	}
 
 	// Attempt to retrieve the template referenced in the combination CR
 	template := &v1alpha1.Template{}

--- a/test/e2e/controller_test.go
+++ b/test/e2e/controller_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/combo/api/v1alpha1"
-	"github.com/operator-framework/combo/pkg/controller"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -141,17 +140,6 @@ var _ = Describe("Combination controller", func() {
 				g.Expect(retrievedCombination.Status.Evaluations).To(ContainElements(expectedUpdatedEvaluations))
 
 				return nil
-			}).Should(Succeed())
-		})
-
-		It("should have the ReferencedTemplate label correctly applied on the combination", func() {
-			Eventually(func(g Gomega) error {
-				var retrievedCombination v1alpha1.Combination
-				err := kubeclient.Get(ctx, types.NamespacedName{Name: validCombinationCRCopy.Name}, &retrievedCombination)
-
-				g.Expect(retrievedCombination.Labels).To(HaveKeyWithValue(controller.ReferencedTemplateLabel, validTemplateCRCopy.Name))
-
-				return err
 			}).Should(Succeed())
 		})
 


### PR DESCRIPTION
# Summary
As was suggested in a recent demo of Combo, a controller adding labels to resources that it did not create is not entirely idiomatic. The original intent behind this change was to optimize the number of iterations that needed to occur when finding combinations relevant to a Template; However, this now seems to not be of much use. 

As a result, this PR removes the code that adds and tests for the label.