### PR TITLE
refactor(controller): remove ReferencedTemplate label to be more idiomatic

### DIFF
--- a/test/e2e/controller_test.go
+++ b/test/e2e/controller_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/combo/api/v1alpha1"
-	"github.com/operator-framework/combo/pkg/controller"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -141,17 +140,6 @@ var _ = Describe("Combination controller", func() {
 				g.Expect(retrievedCombination.Status.Evaluations).To(ContainElements(expectedUpdatedEvaluations))
 
 				return nil
-			}).Should(Succeed())
-		})
-
-		It("should have the ReferencedTemplate label correctly applied on the combination", func() {
-			Eventually(func(g Gomega) error {
-				var retrievedCombination v1alpha1.Combination
-				err := kubeclient.Get(ctx, types.NamespacedName{Name: validCombinationCRCopy.Name}, &retrievedCombination)
-
-				g.Expect(retrievedCombination.Labels).To(HaveKeyWithValue(controller.ReferencedTemplateLabel, validTemplateCRCopy.Name))
-
-				return err
 			}).Should(Succeed())
 		})
 


### PR DESCRIPTION
# Summary
As was suggested in a recent demo of Combo, a controller adding labels to resources that it did not create is not entirely idiomatic. The original intent behind this change was to optimize the number of iterations that needed to occur when finding combinations relevant to a Template; However, this now seems to not be of much use.

As a result, this PR removes the code that adds and tests for the label.