### PR TITLE
fix: Corrected 'eval' function to correctly output combinations for issue #72

### DIFF
--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -1,12 +1,8 @@
 package cmd
 
 import (
-	"io"
-	"os"
-	"strings"
 	"testing"
 
-	comboErrors "github.com/operator-framework/combo/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,36 +30,6 @@ func TestFormatReplacements(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, formatReplacements(tt.input), "replacements formatted incorrectly")
-		})
-	}
-}
-
-func TestValidateFile(t *testing.T) {
-	var invalidStream, _ = os.Open("./DOES_NOT_EXIST")
-	for _, tt := range []struct {
-		name  string
-		input io.Reader
-		err   error
-	}{
-		{
-			name:  "validates a valid file correctly",
-			input: strings.NewReader(`foo: bar`),
-			err:   nil,
-		},
-		{
-			name:  "invalidates an empty file",
-			input: strings.NewReader(""),
-			err:   ErrEmptyFile,
-		},
-		{
-			name:  "invalidates an unreadable file",
-			input: invalidStream,
-			err:   comboErrors.ErrCouldNotReadFile,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateFile(tt.input)
-			require.ErrorIs(t, err, tt.err)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jinzhu/copier v0.3.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
@@ -133,7 +134,6 @@ require (
 	github.com/sanposhiho/wastedassign/v2 v2.0.6 // indirect
 	github.com/securego/gosec/v2 v2.8.1 // indirect
 	github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sonatard/noctx v0.0.1 // indirect
 	github.com/sourcegraph/go-diff v0.6.1 // indirect
 	github.com/spf13/afero v1.6.0 // indirect

--- a/pkg/template/builder.go
+++ b/pkg/template/builder.go
@@ -26,7 +26,6 @@ func NewBuilder(file io.Reader, combinations CombinationStream) (Builder, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build template: %w", err)
 	}
-
 	return &builder{
 		template:     compiledTemplate,
 		combinations: combinations,
@@ -50,7 +49,6 @@ func (g *builder) Build(ctx context.Context) ([]string, error) {
 			if combination == nil {
 				return g.template.processedManifests, nil
 			}
-
 			g.template.with(combination)
 		}
 	}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -198,3 +198,44 @@ func TestWith(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateFile(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		input template
+		err   error
+	}{
+		{
+			name: "validates a valid file correctly",
+			input: template{
+				manifests: []string{
+					"testOne: NAMESPACE",
+					"testTwo: NAME",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "validates an empty file",
+			input: template{
+				processedManifests: []string{},
+			},
+			err: nil,
+		},
+		{
+			name: "invalidates an unreadable file",
+			input: template{
+				manifests: []string{
+					"	apiVersion: rbac.authorization.k8s.io/v1",
+					"kind: ClusterRole",
+				},
+			},
+			err: ErrInvalidYAML,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.input.validate()
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
+}

--- a/test/assets/template/testdata.go
+++ b/test/assets/template/testdata.go
@@ -4,91 +4,91 @@ var BuildInput = `---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-	name: deployment-reader
+    name: deployment-reader
 rules:
 - apiGroups: ["apps"]
-	resources: ["deployments"]
-	verbs: ["get", "watch", "list"]
+  resources: ["deployments"]
+  verbs: ["get", "watch", "list"]
 ---
 kind: Namespace
 metadata:
-	name: NAMESPACE
+    name: NAMESPACE
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-	name: NAME
-	namespace: NAMESPACE
+    name: NAME
+    namespace: NAMESPACE
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-	name: deployment-reader
-	namespace: NAMESPACE
+    name: deployment-reader
+    namespace: NAMESPACE
 subjects:
 - kind: ServiceAccount
-	name: NAME
-	namespace: NAMESPACE
+  name: NAME
+  namespace: NAMESPACE
 roleRef:
-	kind: ClusterRole
-	name: deployment-reader
-	apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: deployment-reader
+    apiGroup: rbac.authorization.k8s.io
 `
 
 var BuildOutput = []string{
 	`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-	name: deployment-reader
+    name: deployment-reader
 rules:
 - apiGroups: ["apps"]
-	resources: ["deployments"]
-	verbs: ["get", "watch", "list"]`,
+  resources: ["deployments"]
+  verbs: ["get", "watch", "list"]`,
 	`kind: Namespace
 metadata:
-	name: foo`,
+    name: foo`,
 
 	`apiVersion: v1
 kind: ServiceAccount
 metadata:
-	name: baz
-	namespace: foo`,
+    name: baz
+    namespace: foo`,
 
 	`apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-	name: deployment-reader
-	namespace: foo
+    name: deployment-reader
+    namespace: foo
 subjects:
 - kind: ServiceAccount
-	name: baz
-	namespace: foo
+  name: baz
+  namespace: foo
 roleRef:
-	kind: ClusterRole
-	name: deployment-reader
-	apiGroup: rbac.authorization.k8s.io`,
+    kind: ClusterRole
+    name: deployment-reader
+    apiGroup: rbac.authorization.k8s.io`,
 
 	`kind: Namespace
 metadata:
-	name: bar`,
+    name: bar`,
 
 	`apiVersion: v1
 kind: ServiceAccount
 metadata:
-	name: baz
-	namespace: bar`,
+    name: baz
+    namespace: bar`,
 
 	`apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-	name: deployment-reader
-	namespace: bar
+    name: deployment-reader
+    namespace: bar
 subjects:
 - kind: ServiceAccount
-	name: baz
-	namespace: bar
+  name: baz
+  namespace: bar
 roleRef:
-	kind: ClusterRole
-	name: deployment-reader
-	apiGroup: rbac.authorization.k8s.io`,
+    kind: ClusterRole
+    name: deployment-reader
+    apiGroup: rbac.authorization.k8s.io`,
 }


### PR DESCRIPTION
## Summary
- fixed test case of builder to correctly validate yaml input
- passes e2e and unit tests
- correctly outputs combinations with the call of `eval` command in the CLI 


Closes #72