### PR TITLE
.github: Remove paths_ignore stanza from relevant workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,10 +2,8 @@ name: build
 on:
   push:
     branches:
-      - main
+    - main
   pull_request:
-    paths-ignore:
-    - '**/*.md'
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,12 +1,10 @@
 name: e2e
 on:
-  pull_request:
-    paths-ignore:
-    - '**/*.md'
-  workflow_dispatch:
   push:
     branches:
     - main
+  pull_request:
+  workflow_dispatch:
 jobs:
   kind:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -2,7 +2,7 @@ name: rebase pull request
 on:
   push:
     branches:
-    - "main"
+    - main
 jobs:
   rebase:
     runs-on: ubuntu-latest

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -2,10 +2,8 @@ name: sanity
 on:
   push:
     branches:
-      - main
+    - main
   pull_request:
-    paths-ignore:
-    - '**/*.md'
   workflow_dispatch:
 jobs:
   sanity:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -2,10 +2,8 @@ name: unit
 on:
   push:
     branches:
-      - main
+    - main
   pull_request:
-    paths-ignore:
-    - '**/*.md'
   workflow_dispatch:
 jobs:
   unit:


### PR DESCRIPTION
Remove the paths_ignore stanza as it doesn't report back workflow status
correctly when checks are skipped due to markdown-only PRs, which
doesn't play well with how branch protection rules are evaluated.

Signed-off-by: timflannagan <timflannagan@gmail.com>