### PR TITLE
fix: correct implementation of nextIterativeCombination method to handle singular input

### DIFF
--- a/pkg/combination/combination.go
+++ b/pkg/combination/combination.go
@@ -86,6 +86,17 @@ func (cs *stream) nextIterativeCombination() (map[string]string, error) {
 	// comboList is a variable that holds a list of combinations to be returned.
 	comboList := map[string]string{}
 
+	// Edge case: 1 parameter
+	if len(cs.parameterListFromArgs) == 1 {
+		key := cs.parameterListFromArgs[0]
+		comboList[key] = cs.args[cs.parameterListFromArgs[0]][cs.positionsMapInArgs[0]]
+		cs.positionsMapInArgs[0]++
+		if cs.positionsMapInArgs[0] == len(cs.args[cs.parameterListFromArgs[0]]) {
+			cs.solved = true
+		}
+		return comboList, nil
+	}
+
 	// Generate the list of combinations based off current positions
 	for x := 0; x < len(cs.parameterListFromArgs); x++ {
 		combo := cs.args[cs.parameterListFromArgs[x]][cs.positionsMapInArgs[x]]

--- a/pkg/combination/combination_test.go
+++ b/pkg/combination/combination_test.go
@@ -28,6 +28,14 @@ var combinationTests = []struct {
 		},
 	},
 	{
+		name:  "standard set of one parameter args",
+		input: testdata.OneParameterCombinationInput,
+		expected: expected{
+			combinations: testdata.OneParameterCombinationOutput,
+			err:          nil,
+		},
+	},
+	{
 		name:  "standard set of args",
 		input: testdata.CombinationInput,
 		expected: expected{

--- a/test/assets/combination/testdata.go
+++ b/test/assets/combination/testdata.go
@@ -1,5 +1,18 @@
 package testdata
 
+var OneParameterCombinationInput = map[string][]string{
+	"TEST1": {"foo", "bar"},
+}
+
+var OneParameterCombinationOutput = []map[string]string{
+	{
+		"TEST1": "foo",
+	},
+	{
+		"TEST1": "bar",
+	},
+}
+
 var CombinationInput = map[string][]string{
 	"TEST1": {"foo", "bar"},
 	"TEST2": {"zip", "zap"},


### PR DESCRIPTION
This PR adds an edge case to `nextIterativeCombination()` method that correctly handles the case given an input of a single parameter

e.g
Input: `test: "foo", "bar"`
Output:
```---
test: foo
---
test: bar
```


closes #80 