### PR TITLE
Version Command Does Not Display in Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ COPY pkg pkg
 COPY main.go main.go
 COPY Makefile Makefile
 
+# copy git-related information for binary version information
+COPY .git/refs .git/refs
+COPY .git/HEAD .git/HEAD
+COPY .git/objects .git/objects
+
 RUN make build-cli
 
 # Copy the binary over to a distroless image and run it

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ GO_BUILD := $(Q)go build
 PKGS := $(shell go list ./...)
 COMBO_VERSION :=  $(shell git describe --match 'v[0-9]*' --tags --always)
 
-
 # Binary build options
 KUBERNETES_VERSION=v0.22.2
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/operator-framework/combo/pkg/controller"
+	"github.com/operator-framework/combo/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -46,6 +47,7 @@ This will reconcile any events for the Combination and Template resources.
 			return err
 		}
 
+		rootLog.Info("Starting Combo", "combo version", version.ComboVersion, "git commit", version.GitCommit, "kubernetes version", version.KubernetesVersion)
 		return mgr.Start(signals.SetupSignalHandler())
 	},
 }


### PR DESCRIPTION
- Modified Dockerfile to include portions of .git directory necessary for
Git describe (the source of version) to successfully execute. Version command
was initially failing because git could not find the necessary information in
the .git directory at the root of the project.

- Added logging announcing version started as part of run command