### PR TITLE
add: created flag to specify verbosity to combo CR controller

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,6 +8,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
+func init() {
+	runCmd.Flags().Int("verbosity", 1, "Sets verbosity level of combo CR controller with default verbosity 1. Verbosity decreases as the value given increases.")
+}
+
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run Combo as a controller on the cluster",
@@ -25,9 +29,14 @@ This will reconcile any events for the Combination and Template resources.
 			return err
 		}
 
+		verbosityLevel, err := cmd.Flags().GetInt("verbosity")
+		if err != nil {
+			return err
+		}
+
 		c, err := controller.NewController(
 			mgr.GetClient(),
-			ctrl.Log.WithName("run"),
+			ctrl.Log.V(verbosityLevel).WithName("run"),
 		)
 		if err != nil {
 			return nil

--- a/pkg/controller/combo_controller.go
+++ b/pkg/controller/combo_controller.go
@@ -79,7 +79,7 @@ func (c *combinationController) Reconcile(ctx context.Context, req ctrl.Request)
 	// Set up a convenient log object so we don’t have to type request over and over again
 	log := c.log.WithValues("request", req)
 
-	log.V(1).Info("new combination event inbound")
+	log.Info("new combination event inbound")
 
 	// Attempt to retrieve the requested combination CR
 	combination := &v1alpha1.Combination{}


### PR DESCRIPTION
## Story
Users are not able to adjust the verbose of Combo's CR controller. A way to adjust this verbosity needs to be implemented in order to allow users to define their logging. 

## Summary
* add flag in the `run` command that allows user to specify verbosity level by calling e.g. `... run --loglvl 3`

## Acceptance Criteria 
* Defined logging approach
* Clear logging levels
* Knob for changing the verbosity

Closes #62