### PR TITLE
Add generated goreleaser yaml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 bin
 
 dist/
+.goreleaser.yml


### PR DESCRIPTION
This fixes an issue with the automated release as seen [here](https://github.com/operator-framework/combo/runs/6293767202?check_suite_focus=true).

Signed-off-by: Catherine Chan-Tse <cchantse@redhat.com>