### PR TITLE
.github,Makefile: Fix the bundle workflow

### DIFF
--- a/.github/workflows/bundle.yaml
+++ b/.github/workflows/bundle.yaml
@@ -10,6 +10,9 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
     - name: Docker Login
       uses: docker/login-action@v1
       with:
@@ -25,11 +28,13 @@ jobs:
         else
           echo BUNDLE_TAG="$(git describe --tags --always)" >> $GITHUB_ENV
         fi
-        echo BUNDLE="quay.io/operator-framework/combo-bundle:${BUNDLE_TAG}" >> $GITHUB_ENV
+        echo BUNDLE_REPO="quay.io/operator-framework/combo-bundle" >> $GITHUB_ENV
 
     - name: Build and push bundle
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v2
       with:
-        file: Dockerfile.plainbundle
-        tags: ${{ env.BUNDLE }}
+        push: true
+        context: ./
+        file: ./Dockerfile.plainbundle
+        tags: ${{ env.BUNDLE_REPO }}:${{ env.BUNDLE_TAG }}
         github-token: ${{ github.token }}

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ COMBO_VERSION :=  $(shell git describe --match 'v[0-9]*' --tags --always)
 export KUBERNETES_VERSION=v0.22.2
 
 # Container build options
-export IMAGE_REPO=quay.io/operator-framework/combo-operator
-export IMAGE_TAG=latest
-IMAGE=$(IMAGE_REPO):$(IMAGE_TAG)
+export IMAGE_REPO ?= quay.io/operator-framework/combo-operator
+export IMAGE_TAG ?= latest
+IMAGE ?= $(IMAGE_REPO):$(IMAGE_TAG)
 
-export BUNDLE_REPO=quay.io/operator-framework/combo-bundle
-export BUNDLE_TAG=latest
-BUNDLE=$(BUNDLE_REPO):$(BUNDLE_TAG)
+export BUNDLE_REPO ?= quay.io/operator-framework/combo-bundle
+export BUNDLE_TAG ?= latest
+BUNDLE ?= $(BUNDLE_REPO):$(BUNDLE_TAG)
 
 # kernel-style V=1 build verbosity
 ifeq ("$(origin V)", "command line")
@@ -67,7 +67,7 @@ verify: tidy generate format lint ## Verify the current code generation and lint
 	git diff --exit-code
 
 VERSION_FLAGS=-ldflags "-X $(VERSION_PATH).GitCommit=$(GIT_COMMIT) -X $(VERSION_PATH).ComboVersion=$(COMBO_VERSION) -X $(VERSION_PATH).KubernetesVersion=$(KUBERNETES_VERSION)"
-build-cli: ## Build the CLI binary. Specify VERSION_PATH, GIT_COMMIT, or KUBERNETES_VERSION to change the binary version. You may also specify BUILD_OS and BUILD_ARCH to change the build's binary. 
+build-cli: ## Build the CLI binary. Specify VERSION_PATH, GIT_COMMIT, or KUBERNETES_VERSION to change the binary version. You may also specify BUILD_OS and BUILD_ARCH to change the build's binary.
 	$(Q) CGO_ENABLED=0 GOOS=$(BUILD_OS) GOARCH=$(BUILD_ARCH) go build $(VERSION_FLAGS) -o ./combo
 
 build-container: BUILD_OS=linux


### PR DESCRIPTION
Update the root Makefile and ensure the image-related variables can be overridden. Overhaul the bundle.yaml GHA workflow to fix failures that arose in https://github.com/operator-framework/combo/actions/runs/2309116312.